### PR TITLE
Fixing table styling for player list

### DIFF
--- a/src/Banner.js
+++ b/src/Banner.js
@@ -18,12 +18,24 @@ function Banner(props) {
     },
   });
 
+  // For some reason I could only get the MUI style working by setting the style directly.
+  // I would like it to be a proper CSS class but either you can't or I'm dumb
+  const iconStyle = {
+    maxHeight: "50px",
+    height: "auto",
+    width: "auto",
+  };
+
   let banner = (
     <Box sx={{ flexGrow: 1 }}>
       <ThemeProvider theme={theme}>
         <AppBar position="static" color="banner">
           <Toolbar className="mona-lisa-banner">
-            <SvgIcon component={props.logo} inheritViewBox></SvgIcon>
+            <SvgIcon
+              style={iconStyle}
+              component={props.logo}
+              inheritViewBox
+            ></SvgIcon>
           </Toolbar>
         </AppBar>
       </ThemeProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -68,6 +68,7 @@ code {
   display: flex;
   justify-content: center;
   padding-top: 15px;
+  padding-bottom: 15px;
 }
 
 .add-server-modal {
@@ -134,16 +135,6 @@ code {
   max-height: 50px;
   height: auto;
   width: auto;
-}
-
-/* This overrides material UI's SvgIcon's default class
-If we need multiple SvgIcons, move this into the react code itself
-AFAIK, in the newest material UI you can't point to a CSS class,
- you have to do the styling in the code itself.  Which is dumb. */
-.MuiSvgIcon-root {
-  max-height: 50px;
-  height: auto !important;
-  width: auto !important;
 }
 
 .player-checkbox-container {


### PR DESCRIPTION
## Changes
- Moving `SvgIcon` styling from a CSS class override to the React code itself.  This is because the `MuiSvgIcon-root` override was impacting the player list page as well, removing key icons
- Adding padding to the "Add Server" button